### PR TITLE
✨ feat : 게시글 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/dearhaeny/dearhaeny/post/query/controller/PostQueryController.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/post/query/controller/PostQueryController.java
@@ -1,6 +1,7 @@
 package com.dearhaeny.dearhaeny.post.query.controller;
 
 import com.dearhaeny.dearhaeny.post.domain.PostType;
+import com.dearhaeny.dearhaeny.post.query.dto.PostDetailResponse;
 import com.dearhaeny.dearhaeny.post.query.dto.PostListResultResponse;
 import com.dearhaeny.dearhaeny.post.query.service.PostQueryService;
 import lombok.RequiredArgsConstructor;
@@ -21,4 +22,12 @@ public class PostQueryController {
     ) {
         return postQueryService.getPostList(category, page, size);
     }
+    @GetMapping("/{postId}")
+    public PostDetailResponse getPostDetail(
+            @PathVariable Long postId
+    ) {
+        return postQueryService.getPostDetail(postId);
+    }
+
+
 }

--- a/src/main/java/com/dearhaeny/dearhaeny/post/query/dto/PostDetailResponse.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/post/query/dto/PostDetailResponse.java
@@ -1,0 +1,22 @@
+package com.dearhaeny.dearhaeny.post.query.dto;
+
+import com.dearhaeny.dearhaeny.post.domain.Post;
+import java.time.LocalDateTime;
+
+public record PostDetailResponse(
+        Long postId,
+        String nickname,
+        String postType,
+        LocalDateTime createdAt,
+        String content
+) {
+    public static PostDetailResponse from(Post post) {
+        return new PostDetailResponse(
+                post.getPostId(),
+                post.getNickname(),
+                post.getPostType().name(),
+                post.getCreatedAt(),
+                post.getContent()
+        );
+    }
+}

--- a/src/main/java/com/dearhaeny/dearhaeny/post/query/service/PostQueryService.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/post/query/service/PostQueryService.java
@@ -2,6 +2,7 @@ package com.dearhaeny.dearhaeny.post.query.service;
 
 import com.dearhaeny.dearhaeny.post.domain.Post;
 import com.dearhaeny.dearhaeny.post.domain.PostType;
+import com.dearhaeny.dearhaeny.post.query.dto.PostDetailResponse;
 import com.dearhaeny.dearhaeny.post.query.dto.PostListResponse;
 import com.dearhaeny.dearhaeny.post.query.dto.PostListResultResponse;
 import com.dearhaeny.dearhaeny.post.repository.PostRepository;
@@ -53,6 +54,12 @@ public class PostQueryService {
                 postPage.hasNext(),            // ⭐ 무한 스크롤 핵심
                 posts
         );
+    }
+    public PostDetailResponse getPostDetail(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
+
+        return PostDetailResponse.from(post);
     }
 }
 


### PR DESCRIPTION
## 작업 내용
- 게시글 단건 조회 API 추가 (/posts/{postId})
- 목록 조회 로직은 기존 코드 유지
- 상세 조회 전용 DTO 분리

## 테스트
- GET /posts/{postId} 