### PR TITLE
♻️Refactor - 게시글 조회 전체 공개 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/dearhaeny/dearhaeny/global/config/SecurityConfig.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/global/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.dearhaeny.dearhaeny.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // 1. CSRF 비활성화 (Stateless API 서버이므로)
+                .csrf(csrf -> csrf.disable())
+
+                // 2. HTTP Basic 인증 및 Form Login 비활성화 (401의 원인 제거)
+                .httpBasic(basic -> basic.disable())
+                .formLogin(form -> form.disable())
+
+                // 3. 경로별 권한 설정
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/posts/**").permitAll() // 게시글 관련 모든 요청 허용
+                        .anyRequest().authenticated()             // 그 외 요청은 인증 필요
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/dearhaeny/dearhaeny/global/web/AnonIdInterceptor.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/global/web/AnonIdInterceptor.java
@@ -3,6 +3,7 @@ package com.dearhaeny.dearhaeny.global.web;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -13,6 +14,11 @@ public class AnonIdInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+
+        // CORS 프리플라이트(OPTIONS) 요청은 무조건 통과
+        if (HttpMethod.OPTIONS.matches(request.getMethod())) {
+            return true;
+        }
 
         // 요청 헤더에서 anonId를 찾기
         String anonId = request.getHeader("anonId");

--- a/src/main/java/com/dearhaeny/dearhaeny/post/query/controller/PostQueryController.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/post/query/controller/PostQueryController.java
@@ -17,7 +17,7 @@ public class PostQueryController {
 
     @GetMapping
     public PostListResultResponse getPosts(
-            @RequestHeader("anonId") String writerUuid,                 // 인터셉터에서 넘겨준 anonId를 받기 위함
+            @RequestHeader(value = "anonId", required = false) String writerUuid,
             @RequestParam(required = false) PostType category, // 전체면 null
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
@@ -27,11 +27,11 @@ public class PostQueryController {
     }
     @GetMapping("/{postId}")
     public PostDetailResponse getPostDetail(
-            @RequestHeader("anonId") String writerUuid,
+            @RequestHeader(value = "anonId", required = false) String writerUuid,
             @PathVariable Long postId
     ) {
 
-        return postQueryService.getPostDetail(postId, writerUuid);
+        return postQueryService.getPostDetail(writerUuid, postId);
     }
 
 }

--- a/src/main/java/com/dearhaeny/dearhaeny/post/query/dto/PostListResultResponse.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/post/query/dto/PostListResultResponse.java
@@ -3,7 +3,6 @@ package com.dearhaeny.dearhaeny.post.query.dto;
 import java.util.List;
 
 public record PostListResultResponse(
-        String writerUuid,          // 브라우저 식별자
         String selectedType,   // ALL / NEW_YEAR_WISH / INNER_THOUGHT / COURAGE
         long totalCount,
         int page,

--- a/src/main/java/com/dearhaeny/dearhaeny/post/query/service/PostQueryService.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/post/query/service/PostQueryService.java
@@ -38,11 +38,11 @@ public class PostQueryService {
 
         // ✅ 전체 조회
         if (postType == null) {
-            postPage = postRepository.findAllByWriterUuid(writerUuid, pageable);
+            postPage = postRepository.findAll(pageable);
         } 
         // ✅ 카테고리 필터
         else {
-            postPage = postRepository.findAllByWriterUuidAndPostType(writerUuid, postType, pageable);
+            postPage = postRepository.findAllByPostType(postType, pageable);
         }
 
         List<PostListResponse> posts = postPage.getContent().stream()
@@ -50,7 +50,6 @@ public class PostQueryService {
                 .toList();
 
         return new PostListResultResponse(
-                writerUuid,
                 postType == null ? "ALL" : postType.name(),
                 postPage.getTotalElements(),   // ⭐ 결과 요약 count
                 postPage.getNumber(),
@@ -59,14 +58,9 @@ public class PostQueryService {
                 posts
         );
     }
-    public PostDetailResponse getPostDetail(Long postId, String writerUuid) {
+    public PostDetailResponse getPostDetail(String writerUuid, Long postId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("게시글이 존재하지 않습니다."));
-
-        // 작성자 본인 확인
-        if (!post.getWriterUuid().equals(writerUuid)) {
-            throw new GeneralException(ErrorStatus.INVALID_WRITER, "본인이 작성한 글에 대해서만 게시물을 조회할 수 있습니다.");
-        }
 
         return PostDetailResponse.from(post);
     }

--- a/src/main/java/com/dearhaeny/dearhaeny/post/repository/PostRepository.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/post/repository/PostRepository.java
@@ -13,5 +13,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     // 목록 조회
     Page<Post> findAllByWriterUuid(String writerUuid, Pageable pageable);
     Page<Post> findAllByWriterUuidAndPostType(String writerUuid, PostType postType, Pageable pageable);
-    
+    Page<Post> findAllByPostType(PostType postType, Pageable pageable);
+
+
 }

--- a/src/main/java/com/dearhaeny/dearhaeny/post/service/PostService.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/post/service/PostService.java
@@ -24,6 +24,12 @@ public class PostService {
     @Transactional
     public PostCreatedResponse sendPost(PostCreateRequest request, String writerUuid) {
 
+        // 인터셉터에서 전달된 ID가 null이라면 직접 생성
+        if (writerUuid == null || writerUuid.isBlank()) {
+            log.warn("writerUuid가 없습니다.");
+            writerUuid = UUID.randomUUID().toString();
+        }
+
         // 게시글을 작성하기 위해서는 모든 필드가 작성돼 있어야 한다
         if (request.getNickname() == null || request.getNickname().isBlank()) {
             throw new GeneralException(ErrorStatus.VALIDATION_ERROR, "닉네임을 입력해 주세요.");

--- a/src/main/java/com/dearhaeny/dearhaeny/reply/controller/ReplyQueryController.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/reply/controller/ReplyQueryController.java
@@ -15,10 +15,9 @@ public class ReplyQueryController {
 
     @GetMapping("/{postId}/reply")
     public ReplyCreatedResponse getReply(
-            @RequestHeader("anonId") String writerUuid,
             @PathVariable Long postId
     ) {
 
-        return replyService.getReplyByPostId(postId, writerUuid);
+        return replyService.getReplyByPostId(postId);
     }
 }

--- a/src/main/java/com/dearhaeny/dearhaeny/reply/service/ReplyService.java
+++ b/src/main/java/com/dearhaeny/dearhaeny/reply/service/ReplyService.java
@@ -156,18 +156,12 @@ public class ReplyService {
     }
 
     @Transactional
-    public ReplyCreatedResponse getReplyByPostId(Long postId, String writerUuid) {
+    public ReplyCreatedResponse getReplyByPostId(Long postId) {
 
         Reply reply = replyRepository.findByPost_PostId(postId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.REPLY_NOT_FOUND));
 
-        // 작성자 본인 확인
-        if (!reply.getPost().getWriterUuid().equals(writerUuid)) {
-            throw new GeneralException(ErrorStatus.INVALID_WRITER, "본인이 작성한 글에 대해서만 게시물을 조회할 수 있습니다.");
-        }
-
         return ReplyCreatedResponse.builder()
-                .writerUuid(reply.getPost().getWriterUuid())
                 .replyId(reply.getReplyId())
                 .content(reply.getContent())
                 .replyStatus(reply.getStatus())


### PR DESCRIPTION
#18 
> 게시글 조회 전체 공개 전환

## ✨ Description
> 사용자별 필터링 제거 (모든 사용자에 대한 전체 조회 전환)

## 📌 구현 내용

- [x] **Spring Security 도입**
 - SecurityConfig를 추가하여 /posts/** 경로에 대한 permitAll() 설정을 적용
- [x] **게시물 목록 및 단건 조회 시 모든 사용자가 작성한 게시글에 대해 적용**
 - 조회 범위 확장: PostQueryService 및 PostRepository에서 `writerUuid` 필터링을 제거
    → 모든 사용자가 게시글 목록과 상세 내용을 확인
